### PR TITLE
Add projectType field to project metadata and update display logic

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,10 +4,10 @@ import { defineCollection, z } from 'astro:content';
 const contentSchema = z.object({
 	title: z.string(),
 	description: z.string(),
-	// Transform string to Date object
 	pubDate: z.coerce.date(),
 	updatedDate: z.coerce.date().optional(),
 	heroImage: z.string().optional(),
+	projectType : z.string().optional(),
 });
 
 const blog = defineCollection({

--- a/src/content/projects/projet1.md
+++ b/src/content/projects/projet1.md
@@ -3,6 +3,7 @@ title: 'Shampoo Sales Analysis'
 description: 'A Machine Learning Time Series Problem'
 pubDate: 'November 2024'
 heroImage: /shampoo.webp
+projectType : ML
 ---
 
 ## Background & Objective

--- a/src/content/projects/projet2.md
+++ b/src/content/projects/projet2.md
@@ -3,6 +3,7 @@ title: 'Demographic Data Analyzer'
 description: 'An Exploratory Data Analysis Project'
 pubDate: 'November 2024'
 heroImage: /proj21.webp
+projectType : Machine Learning
 ---
 
 The dataset is derived from the 1994 Census database, containing 32,561 rows and 15 columns. The aim of this project is to demonstrate how to use the powerful Pandas library to analyze data by answering business questions.

--- a/src/content/projects/projet3.md
+++ b/src/content/projects/projet3.md
@@ -3,6 +3,7 @@ title: 'Adventure Works'
 description: 'A Data visualization Project with Power BI'
 pubDate: 'August 2024'
 heroImage: /proj3.webp
+projectType : Lampe
 ---
 
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,7 +51,13 @@ const projects = (await getCollection('projects')).sort(
 								<h3 class="text-gray-950 dark:text-white">
 									{project.data.title}
 								</h3>
-								<span class="text-sm text-gray-500 dark:text-gray-300">Web Design</span>
+								{
+									project.data.projectType && (
+										<span class="text-sm text-gray-500 dark:text-gray-300">
+											{project.data.projectType}
+										</span>
+									)
+								}
 							</div>
 						</a>
 					))


### PR DESCRIPTION
This pull request includes changes to the content configuration and project files to add a new `projectType` field, as well as updates to the index page to display this new field if it exists.

### Content Configuration Updates:
* [`src/content.config.ts`](diffhunk://#diff-0d78708eb6a4cf32e1758b9f04d0f05b751a26662664493a7c066252a0012f35L7-R10): Added `projectType` as an optional string field in the `contentSchema`.

### Project Files Updates:
* [`src/content/projects/projet1.md`](diffhunk://#diff-2099471b31814a000ee6c5b9fccf507032d4a2b7c6dddf2bc4e0a6ac043f9f9bR6): Added `projectType` field with value `ML`.
* [`src/content/projects/projet2.md`](diffhunk://#diff-6aae0c0c3e4597fa42ccfeca1258d23216e34ef8ff1017a541f8edfcff22eb45R6): Added `projectType` field with value `Machine Learning`.
* [`src/content/projects/projet3.md`](diffhunk://#diff-a8b8fef044351c25e7bc85200027a16a957a30f236ca18d10554cd7f983ea302R6): Added `projectType` field with value `Lampe`.

### Index Page Update:
* [`src/pages/index.astro`](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L54-R60): Updated to conditionally display the `projectType` field if it exists.